### PR TITLE
Adding methods and changing the API in goish way

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Fast int64 -> int64 hash in golang.
 Package intintmap is a fast int64 key -> int64 value map.
 
 It is copied nearly verbatim from
-http://java-performance.info/implementing-world-fastest-java-int-to-int-hash-map/
+http://java-performance.info/implementing-world-fastest-java-int-to-int-hash-map/ .
 
 It interleaves keys and values in the same underlying array to improve locality.
 
@@ -29,7 +29,6 @@ differentiate (or use math.MinUint32 if that hurts performance).
 
 ## Usage
 
-
 ```go
 m := intintmap.New(32768, 0.6)
 m.Put(int64(1234), int64(-222))
@@ -40,6 +39,16 @@ m.Get(int64(333))
 
 m.Del(int64(222))
 m.Del(int64(333))
+
+m.Size()
+
+for k := range m.Keys() {
+    fmt.Printf("key: %d\n", k)
+}
+
+for kv := range m.Items() {
+    fmt.Printf("key: %d, value: %d\n", kv[0], kv[1])
+}
 ```
 
 #### type Map
@@ -74,18 +83,32 @@ func (m *Map) Put(key int64, val int64) int64
 Put adds val to the map under the specified key and returns the old value in
 that key.
 
+#### func (*Map) Del
+
 ```go
 func (m *Map) Del(key int64) int64
 ```
-Del deletes an key and its value, and returns the value or NO_VALUE if the
+Del deletes a key and its value, and returns the value or NO_VALUE if the
 key is not found.
+
+#### func (*Map) Keys
 
 ```go
 func (m *Map) Keys() chan int64
 ```
-Keys returns a channel for all keys.
+Keys returns a channel for iterating all keys.
+
+#### func (*Map) Items
 
 ```go
 func (m *Map) Items() chan [2]int64
 ```
-Items returns a channel for all key-value pairs.
+Items returns a channel for iterating all key-value pairs.
+
+
+#### func (*Map) Size
+
+```go
+func (m *Map) Size() int
+```
+Size returns size of the map.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Fast int64 -> int64 hash in golang.
 
-[![GoDoc] (https://godoc.org/github.com/brentp/intintmap?status.png)](https://godoc.org/github.com/brentp/intintmap)
+[![GoDoc] (https://godoc.org/github.com/brentp/intintmap?status.svg)](https://godoc.org/github.com/brentp/intintmap)
 
 # intintmap
---
+
     import "github.com/brentp/intintmap"
 
 Package intintmap is a fast int64 key -> int64 value map.
@@ -36,6 +36,9 @@ m.Put(int64(123), int64(33))
 
 m.Get(int64(222))
 m.Get(int64(333))
+
+m.Del(int64(222))
+m.Del(int64(333))
 ```
 
 #### type Map
@@ -69,3 +72,8 @@ func (m *Map) Put(key int64, val int64) int64
 ```
 Put adds val to the map under the specified key and returns the old value in
 that key.
+
+```go
+func (m *Map) Del(key int64) int64
+```
+Del deletes an key and its value, and returns the value or NO_VALUE if the key is not found

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ BenchmarkIntIntMapGet100PercentHitRate 	     500	   2249349 ns/op
 BenchmarkStdMapGet100PercentHitRate    	     100	  10258929 ns/op
 ```
 
-**note** it currently returns 0 for missing keys. Should probably make Get() return (int, error) so we can
-differentiate (or use math.MinUint32 if that hurts performance).
-
 ## Usage
 
 ```go
@@ -34,13 +31,13 @@ m := intintmap.New(32768, 0.6)
 m.Put(int64(1234), int64(-222))
 m.Put(int64(123), int64(33))
 
-m.Get(int64(222))
-m.Get(int64(333))
+v, ok := m.Get(int64(222))
+v, ok := m.Get(int64(333))
 
 m.Del(int64(222))
 m.Del(int64(333))
 
-m.Size()
+fmt.Println(m.Size())
 
 for k := range m.Keys() {
     fmt.Printf("key: %d\n", k)
@@ -63,7 +60,7 @@ Map is a map-like data-structure for int64s
 #### func  New
 
 ```go
-func New(n int, fillFactor float64) *Map
+func New(size int, fillFactor float64) *Map
 ```
 New returns a map initialized with n spaces and uses the stated fillFactor. The
 map will grow as needed.
@@ -71,25 +68,23 @@ map will grow as needed.
 #### func (*Map) Get
 
 ```go
-func (m *Map) Get(key int64) int64
+func (m *Map) Get(key int64) (int64, bool)
 ```
-Get returns the value or NO_VALUE if the key is not found.
+Get returns the value if the key is found.
 
 #### func (*Map) Put
 
 ```go
-func (m *Map) Put(key int64, val int64) int64
+func (m *Map) Put(key int64, val int64)
 ```
-Put adds val to the map under the specified key and returns the old value in
-that key.
+Put adds or updates key with value val.
 
 #### func (*Map) Del
 
 ```go
-func (m *Map) Del(key int64) int64
+func (m *Map) Del(key int64)
 ```
-Del deletes a key and its value, and returns the value or NO_VALUE if the
-key is not found.
+Del deletes a key and its value.
 
 #### func (*Map) Keys
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Fast int64 -> int64 hash in golang.
 
-[![GoDoc] (https://godoc.org/github.com/brentp/intintmap?status.svg)](https://godoc.org/github.com/brentp/intintmap)
+[![GoDoc](https://godoc.org/github.com/brentp/intintmap?status.svg)](https://godoc.org/github.com/brentp/intintmap)
+[![Go Report Card](https://goreportcard.com/badge/github.com/brentp/intintmap)](https://goreportcard.com/report/github.com/brentp/intintmap)
 
 # intintmap
 
@@ -76,4 +77,15 @@ that key.
 ```go
 func (m *Map) Del(key int64) int64
 ```
-Del deletes an key and its value, and returns the value or NO_VALUE if the key is not found
+Del deletes an key and its value, and returns the value or NO_VALUE if the
+key is not found.
+
+```go
+func (m *Map) Keys() chan int64
+```
+Keys returns a channel for all keys.
+
+```go
+func (m *Map) Items() chan [2]int64
+```
+Items returns a channel for all key-value pairs.

--- a/intintmap.go
+++ b/intintmap.go
@@ -7,9 +7,11 @@ import (
 	"math"
 )
 
+// INT_PHI is for scrambling the keys
 const INT_PHI = 0x9E3779B9
+
+// FREE_KEY is the 'free' key
 const FREE_KEY = 0
-const NO_VALUE = 0
 
 func phiMix(x int64) int64 {
 	h := x * INT_PHI
@@ -77,14 +79,14 @@ func (m *Map) Get(key int64) (int64, bool) {
 		if m.hasFreeKey {
 			return m.freeVal, true
 		}
-		return NO_VALUE, false
+		return 0, false
 	}
 
 	ptr := (phiMix(key) & m.mask) << 1
 	k := m.data[ptr]
 
 	if key == FREE_KEY { // end of chain already
-		return NO_VALUE, false
+		return 0, false
 	}
 	if k == key { // we check FREE prior to this call
 		return m.data[ptr+1], true
@@ -94,7 +96,7 @@ func (m *Map) Get(key int64) (int64, bool) {
 		ptr = (ptr + 2) & m.mask2
 		k = m.data[ptr]
 		if k == FREE_KEY {
-			return NO_VALUE, false
+			return 0, false
 		}
 		if k == key {
 			return m.data[ptr+1], true

--- a/intintmap.go
+++ b/intintmap.go
@@ -236,7 +236,7 @@ func (m *Map) rehash() {
 	copy(data, m.data)
 
 	m.data = make([]int64, newCapacity)
-	if m.hasFreeKey {
+	if m.hasFreeKey { // reset size
 		m.size = 1
 	} else {
 		m.size = 0

--- a/intintmap_test.go
+++ b/intintmap_test.go
@@ -27,8 +27,6 @@ func TestMapSimple(t *testing.T) {
 		t.Errorf("size (%d) is not right, should be %d", m.Size(), int(20000/2)-1)
 	}
 
-	return
-
 	// --------------------------------------------------------------------
 	// Keys()
 

--- a/intintmap_test.go
+++ b/intintmap_test.go
@@ -1,10 +1,13 @@
 package intintmap
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMapSimple(t *testing.T) {
 	m := New(10, 0.99)
 	var i int64
+
 	for i = 2; i < 20000; i += 2 {
 		m.Put(i, i)
 	}
@@ -16,8 +19,11 @@ func TestMapSimple(t *testing.T) {
 			t.Errorf("didn't get expected NO-VALUE value")
 		}
 	}
+
 	for i = 2; i < 20000; i += 2 {
-		m.Put(i, 2*i)
+		m.Put(i, i*2)
+	}
+	for i = 2; i < 20000; i += 2 {
 		if m.Get(i) != 2*i {
 			t.Errorf("didn't get expected value")
 		}
@@ -25,6 +31,19 @@ func TestMapSimple(t *testing.T) {
 			t.Errorf("didn't get expected NO-VALUE value")
 		}
 	}
+
+	for i = 2; i < 20000; i += 2 {
+		m.Del(i)
+	}
+	for i = 2; i < 20000; i += 2 {
+		if m.Get(i) != NO_VALUE {
+			t.Errorf("didn't get expected NO-VALUE value")
+		}
+		if m.Get(i+1) != NO_VALUE {
+			t.Errorf("didn't get expected NO-VALUE value")
+		}
+	}
+
 }
 
 func TestMap(t *testing.T) {

--- a/intintmap_test.go
+++ b/intintmap_test.go
@@ -20,7 +20,7 @@ func TestMapSimple(t *testing.T) {
 		if v, ok = m.Get(i); !ok || v != i {
 			t.Errorf("didn't get expected value")
 		}
-		if v, ok = m.Get(i + 1); ok {
+		if _, ok = m.Get(i + 1); ok {
 			t.Errorf("didn't get expected 'not found' flag")
 		}
 	}
@@ -101,7 +101,7 @@ func TestMapSimple(t *testing.T) {
 		if v, ok = m.Get(i); !ok || v != i*2 {
 			t.Errorf("didn't get expected value")
 		}
-		if v, ok = m.Get(i + 1); ok {
+		if _, ok = m.Get(i + 1); ok {
 			t.Errorf("didn't get expected 'not found' flag")
 		}
 	}

--- a/intintmap_test.go
+++ b/intintmap_test.go
@@ -20,6 +20,53 @@ func TestMapSimple(t *testing.T) {
 		}
 	}
 
+	// --------------------------------------------------------------------
+
+	m0 := make(map[int64]int64, 1000)
+	for i = 2; i < 20000; i += 2 {
+		m0[i] = i
+	}
+	n := len(m0)
+
+	for k := range m.Keys() {
+		m0[k] = -k
+	}
+	if n != len(m0) {
+		t.Errorf("get unexpected more keys")
+	}
+
+	for k, v := range m0 {
+		if k != -v {
+			t.Errorf("didn't get expected changed key")
+		}
+	}
+
+	// --------------------------------------------------------------------
+
+	m0 = make(map[int64]int64, 1000)
+	for i = 2; i < 20000; i += 2 {
+		m0[i] = i
+	}
+	n = len(m0)
+
+	for kv := range m.Items() {
+		m0[kv[0]] = -kv[1]
+		if kv[0] != kv[1] {
+			t.Errorf("didn't get expected key-value pair")
+		}
+	}
+	if n != len(m0) {
+		t.Errorf("get unexpected more keys")
+	}
+
+	for k, v := range m0 {
+		if k != -v {
+			t.Errorf("didn't get expected changed key")
+		}
+	}
+
+	// --------------------------------------------------------------------
+
 	for i = 2; i < 20000; i += 2 {
 		m.Put(i, i*2)
 	}
@@ -31,6 +78,8 @@ func TestMapSimple(t *testing.T) {
 			t.Errorf("didn't get expected NO-VALUE value")
 		}
 	}
+
+	// --------------------------------------------------------------------
 
 	for i = 2; i < 20000; i += 2 {
 		m.Del(i)

--- a/intintmap_test.go
+++ b/intintmap_test.go
@@ -8,6 +8,9 @@ func TestMapSimple(t *testing.T) {
 	m := New(10, 0.99)
 	var i int64
 
+	// --------------------------------------------------------------------
+	// Put() and Get()
+
 	for i = 2; i < 20000; i += 2 {
 		m.Put(i, i)
 	}
@@ -20,7 +23,14 @@ func TestMapSimple(t *testing.T) {
 		}
 	}
 
+	if m.Size() != int(20000/2)-1 {
+		t.Errorf("size (%d) is not right, should be %d", m.Size(), int(20000/2)-1)
+	}
+
+	return
+
 	// --------------------------------------------------------------------
+	// Keys()
 
 	m0 := make(map[int64]int64, 1000)
 	for i = 2; i < 20000; i += 2 {
@@ -42,6 +52,7 @@ func TestMapSimple(t *testing.T) {
 	}
 
 	// --------------------------------------------------------------------
+	// Items()
 
 	m0 = make(map[int64]int64, 1000)
 	for i = 2; i < 20000; i += 2 {
@@ -66,20 +77,7 @@ func TestMapSimple(t *testing.T) {
 	}
 
 	// --------------------------------------------------------------------
-
-	for i = 2; i < 20000; i += 2 {
-		m.Put(i, i*2)
-	}
-	for i = 2; i < 20000; i += 2 {
-		if m.Get(i) != 2*i {
-			t.Errorf("didn't get expected value")
-		}
-		if m.Get(i+1) != NO_VALUE {
-			t.Errorf("didn't get expected NO-VALUE value")
-		}
-	}
-
-	// --------------------------------------------------------------------
+	// Del()
 
 	for i = 2; i < 20000; i += 2 {
 		m.Del(i)
@@ -87,6 +85,21 @@ func TestMapSimple(t *testing.T) {
 	for i = 2; i < 20000; i += 2 {
 		if m.Get(i) != NO_VALUE {
 			t.Errorf("didn't get expected NO-VALUE value")
+		}
+		if m.Get(i+1) != NO_VALUE {
+			t.Errorf("didn't get expected NO-VALUE value")
+		}
+	}
+
+	// --------------------------------------------------------------------
+	// Put() and Get()
+
+	for i = 2; i < 20000; i += 2 {
+		m.Put(i, i*2)
+	}
+	for i = 2; i < 20000; i += 2 {
+		if m.Get(i) != 2*i {
+			t.Errorf("didn't get expected value")
 		}
 		if m.Get(i+1) != NO_VALUE {
 			t.Errorf("didn't get expected NO-VALUE value")


### PR DESCRIPTION
Hi @brentp ,

This PR includes:

1. Adding methods:
    - `Del` for deleting a key-value pair.
    - `Keys`  returns a channel for iterating keys.
    - `Items` returns a channel for iterating all key-value pairs.
    - `Size` returns the map size.
1. Fixing a bug:
    - `rehash()` [forgets to reset map size](https://github.com/brentp/intintmap/compare/master...shenwei356:master#diff-48e43679779477d0f67ff2936360da3aR232), which brought incorrect (bigger) map size and prematurely rehashing.
1. Changing APIs in goish way
    - `Get`: Function in Java does not supports returning multiple values, so the original implemention uses a `NO_VALUE` to indicating keys no found. But golang does, so  we can just returns another boolean value like builtin `map` does (`value, ok := m[key]`).
    - `Put` does not need returning value.
1. And of cause updated tests and README.
