### PR TITLE
go.mod: Fix module path.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module intintmap
+module github.com/brentp/intintmap


### PR DESCRIPTION
PR should fix:
> module declares its path as: intintmap
> but was required as: github.com/brentp/intintmap

This has been really annoying, would love if it gets merged.